### PR TITLE
Fix cop count logic

### DIFF
--- a/drugwars/events.py
+++ b/drugwars/events.py
@@ -3,16 +3,20 @@ from .helpers import check_ans_yn, clear, round_down, check_ans_bsj, check_drug_
 from .classes import Prices
 from random import randint, choice
 
+
+def cops_for_roll(r):
+    """Return the number of cops chasing based on the roll."""
+    if 1 <= r <= 6:
+        return 2
+    elif 7 <= r <= 9:
+        return 3
+    else:
+        return 4
+
 def cops_chase(player):
     if 1 == randint(1, 10):
-        cops = 0
         r = randint(1, 10)
-        if r >= 1 or r <= 6:
-            cops = 2
-        elif r >= 7 or r <= 9:
-            cops = 3
-        else:
-            cops = 4
+        cops = cops_for_roll(r)
         print(SingleTable([["Officer Headass and " + str(cops) + " other(s) are chasing you!"]]).table)
         if player.guns >= 1:
             while True:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from drugwars import events
+
+@pytest.mark.parametrize("r,expected", [
+    (1,2), (2,2), (3,2), (4,2), (5,2), (6,2),
+    (7,3), (8,3), (9,3),
+    (10,4)
+])
+def test_cops_for_roll(r, expected):
+    assert events.cops_for_roll(r) == expected
+


### PR DESCRIPTION
## Summary
- correct cop count by using range checks
- expose helper `cops_for_roll` for clarity
- test all possible roll values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851eb299c7483229512621be428321c