### PR TITLE
Add unit tests for Player actions and interest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 terminaltables==3.1.0
+pytest>=6.0
 

--- a/tests/test_player_bank.py
+++ b/tests/test_player_bank.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from drugwars.classes import Player
+from drugwars.helpers import round_down
+
+
+def test_player_buy_updates_inventory_and_money():
+    p = Player()
+    p.buy('weed', 5, 10)
+    assert p.weed == 5
+    assert p.money == 2000 - 5 * 10
+
+
+def test_player_sell_updates_inventory_and_money():
+    p = Player()
+    p.weed = 8
+    p.sell('weed', 3, 20)
+    assert p.weed == 5
+    assert p.money == 2000 + 3 * 20
+
+
+def test_can_buy_exceed_coat_space_false():
+    p = Player()
+    p.max_trench = 10
+    assert not p.can_buy(price=1, amount=20)
+
+
+def test_bank_interest():
+    p = Player()
+    p.bank.balance = 1000
+    p.bank.interest()
+    assert p.bank.balance == int(round_down(1000 * 1.05))
+
+
+def test_shark_interest():
+    p = Player()
+    p.shark.balance = 1000
+    p.shark.interest()
+    assert p.shark.balance == int(round_down(1000 * 1.08))
+
+
+def test_shark_borrow_too_much():
+    p = Player()
+    p.money = 2000
+    p.shark.balance = 1000
+    assert not p.shark.check_can_borrow(1500)
+


### PR DESCRIPTION
## Summary
- add pytest dependency
- test Player buying and selling logic
- test coat space limits and loan shark borrowing rules
- verify bank and shark interest calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851efa181bc83229534a9ffd7e4b1da